### PR TITLE
Add signup popover

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -6,6 +6,7 @@ type ButtonProps = {
   size?: 'sm' | 'md' | 'lg';
   className?: string;
   onClick?: () => void;
+  type?: 'button' | 'submit' | 'reset';
 };
 
 const Button: React.FC<ButtonProps> = ({
@@ -14,6 +15,7 @@ const Button: React.FC<ButtonProps> = ({
   size = 'md',
   className = '',
   onClick,
+  type = 'button',
 }) => {
   const baseStyles = "font-medium rounded-md transition-all duration-300 inline-flex items-center justify-center";
   
@@ -30,7 +32,8 @@ const Button: React.FC<ButtonProps> = ({
   };
   
   return (
-    <button 
+    <button
+      type={type}
       className={`${baseStyles} ${variantStyles[variant]} ${sizeStyles[size]} ${className}`}
       onClick={onClick}
     >

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import Button from './Button';
+import SignupModal from './SignupModal';
 
 const Hero: React.FC = () => {
   const [currentText, setCurrentText] = useState('');
   const [showSuggestion, setShowSuggestion] = useState(false);
   const [showGrammar, setShowGrammar] = useState(false);
+  const [showSignup, setShowSignup] = useState(false);
 
   const fullText = "We're excited to share our product roadmap for Q2. The team has made significant progress on the new features. Can you review and provide feedback?";
   
@@ -28,6 +30,7 @@ const Hero: React.FC = () => {
   }, []);
 
   return (
+    <>
     <section className="pt-32 pb-20 overflow-hidden">
       <div className="container mx-auto px-6">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
@@ -44,7 +47,12 @@ const Hero: React.FC = () => {
             </p>
             
             <div className="mt-8 flex flex-col sm:flex-row items-center gap-4">
-              <Button variant="primary" size="lg" className="w-full sm:w-auto">
+              <Button
+                variant="primary"
+                size="lg"
+                className="w-full sm:w-auto"
+                onClick={() => setShowSignup(true)}
+              >
                 Start my 7-day trial
               </Button>
               <Button variant="outline" size="lg" className="w-full sm:w-auto">
@@ -165,6 +173,8 @@ const Hero: React.FC = () => {
         </div>
       </div>
     </section>
+    <SignupModal open={showSignup} onClose={() => setShowSignup(false)} />
+    </>
   );
 };
 

--- a/src/components/SignupModal.tsx
+++ b/src/components/SignupModal.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import Button from './Button';
+
+type SignupModalProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+const SignupModal: React.FC<SignupModalProps> = ({ open, onClose }) => {
+  const [email, setEmail] = useState('');
+
+  if (!open) return null;
+
+  const handleSubmit = () => {
+    window.location.href = `mailto:jeff@thatsheaps.com?subject=Inkline%20Signup&body=Email:%20${encodeURIComponent(email)}`;
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg shadow-lg p-6 w-80">
+        <h2 className="text-lg font-medium text-slate-800 mb-4">Start your free trial</h2>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Your email"
+          className="w-full border border-slate-300 rounded-md p-2 mb-4 text-slate-700"
+        />
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" size="md" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="primary" size="md" onClick={handleSubmit}>
+            Submit
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SignupModal;


### PR DESCRIPTION
## Summary
- add button `type` support
- create `SignupModal` component to collect email
- show signup modal from hero CTA

## Testing
- `npm run lint`