### PR TITLE
Fix noscript tag error

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,13 +20,15 @@
       fbq('init', '1263127035333773');
       fbq('track', 'PageView');
     </script>
-    <noscript><img height="1" width="1" style="display:none"
-      src="https://www.facebook.com/tr?id=1263127035333773&ev=PageView&noscript=1"
-    /></noscript>
     <!-- End Meta Pixel Code -->
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <noscript>
+      <img height="1" width="1" style="display:none"
+        src="https://www.facebook.com/tr?id=1263127035333773&ev=PageView&noscript=1"
+      />
+    </noscript>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- move Meta Pixel `noscript` from `<head>` to `<body>` to comply with HTML rules

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*