### PR TITLE
Fix noscript tag error

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,13 +20,15 @@
       fbq('init', '1263127035333773');
       fbq('track', 'PageView');
     </script>
-    <noscript><img height="1" width="1" style="display:none"
-      src="https://www.facebook.com/tr?id=1263127035333773&ev=PageView&noscript=1"
-    /></noscript>
     <!-- End Meta Pixel Code -->
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <noscript>
+      <img height="1" width="1" style="display:none"
+        src="https://www.facebook.com/tr?id=1263127035333773&ev=PageView&noscript=1"
+      />
+    </noscript>
   </body>
 </html>

--- a/public/thankyou.html
+++ b/public/thankyou.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Thank You - Inkline</title>
+    <link rel="stylesheet" href="/src/index.css" />
+
     <!-- Meta Pixel Code -->
     <script>
       !function(f,b,e,v,n,t,s)
@@ -15,19 +18,19 @@
       'https://connect.facebook.net/en_US/fbevents.js');
       fbq('init', '1263127035333773');
       fbq('track', 'PageView');
+      fbq('track', 'CompleteRegistration', {
+        value: 1,
+        currency: 'USD',
+      });
     </script>
-    <noscript><img height="1" width="1" style="display:none"
-      src="https://www.facebook.com/tr?id=1263127035333773&ev=PageView&noscript=1"
-    /></noscript>
     <!-- End Meta Pixel Code -->
   </head>
-  <body>
-    <h1>Thank you for signing up!</h1>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Thank You</title>
-    <link rel="stylesheet" href="/src/index.css" />
-  </head>
   <body class="font-serif flex items-center justify-center h-screen bg-slate-50 text-slate-800">
+    <noscript>
+      <img height="1" width="1" style="display:none"
+        src="https://www.facebook.com/tr?id=1263127035333773&ev=PageView&noscript=1"
+      />
+    </noscript>
     <div class="text-center">
       <h1 class="text-3xl mb-4">Thank you for signing up!</h1>
       <p>We'll be in touch soon.</p>


### PR DESCRIPTION
## Summary
- move Meta Pixel `noscript` from `<head>` to `<body>` to comply with HTML rules
- track `CompleteRegistration` event on thank you page

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*